### PR TITLE
v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Brewski Bets is the official platform for betting brewskis on the FIFA World Cup
 <h2>Releases</h2>
 
 <details>
+<summary style="cursor: pointer">v1.0.1</summary>
+
+**Released on October 23rd, 2022**
+
+<h4 style="color: red">Bug Fixes</h4>
+
+- [Frontend] Restrict width of details area in `bet-table` so that horizontal scrolling is never necessary
+- [Frontend] Reduce height of `bet-editor` so that it's fully visible on mobile
+- [Frontend] Remove `overflow: hidden;` CSS rule on `table` element for the table header and footer to remain sticky on mobile
+
+</details>
+
+<details>
 <summary style="cursor: pointer">v1.0.0</summary>
 
 **Released on October 23rd, 2022**

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -17,5 +17,5 @@ bb-header,
 bb-footer {
   flex-shrink: 0;
   width: 100%;
-  background-color: hsla(97, 35%, 88%);
+  background-color: hsl(97, 35%, 88%);
 }

--- a/src/app/bet-editor/bet-editor.component.scss
+++ b/src/app/bet-editor/bet-editor.component.scss
@@ -41,6 +41,7 @@ section {
   text-align: center;
 }
 
+
 button.close {
   background: none;
   width: 30px;
@@ -51,6 +52,10 @@ button.close {
   top: 0;
   left: 0;
   padding: 2px;
+}
+
+h3 {
+  margin: 8px 0;
 }
 
 form {
@@ -74,7 +79,7 @@ fieldset {
   align-items: center;
   gap: 6px;
   border: none;
-  padding: 1em 0;
+  padding: 8px 0;
 
   .form-field {
     display: flex;
@@ -128,7 +133,7 @@ fieldset {
 }
 
 h4 {
-  margin: 1.4em 0 0;
+  margin: 24px 0 0;
   font-size: 14px;
   font-weight: normal;
 }
@@ -140,7 +145,7 @@ hr {
   border-top: 1px solid rgba(194, 194, 194, 0.6);
 
   & + fieldset {
-    padding-top: 0.2em;
+    padding-top: 0;
   }
 }
 
@@ -153,7 +158,7 @@ hr {
     &.submit,
     &.delete {
       padding: 4px 12px;
-      margin: 16px 0 8px;
+      margin: 8px 0;
       border: 1px solid hsla(0, 0%, 87%, 0.5);
       border-radius: 4px;
     }

--- a/src/app/bet-table/bet-table.component.scss
+++ b/src/app/bet-table/bet-table.component.scss
@@ -13,7 +13,6 @@
 table {
   max-width: 600px;
   box-shadow: 3px 2px 8px 0 hsla(0, 0%, 89%, 0.7);
-  overflow: hidden;
   border-radius: 4px;
   border-collapse: collapse;
 
@@ -75,7 +74,7 @@ table {
     }
 
     &:hover {
-      background-color: hsla(199, 43%, 83%, 0.272);
+      background-color: hsla(199, 43%, 83%, 0.3);
       cursor: pointer;
     }
 
@@ -84,8 +83,12 @@ table {
 
       &.bet-details {
         min-width: 120px;
+        max-width: 160px;
         font-size: 12px;
         white-space: pre-wrap;
+        overflow-wrap: break-word;  
+        word-wrap: break-word; 
+        word-break: break-word;
 
         &.done {
           color:hsla(0, 0%, 20%, 0.4);


### PR DESCRIPTION
Bug Fixes
- [Frontend] Restrict width of details area in `bet-table` so that horizontal scrolling is never necessary
- [Frontend] Reduce height of `bet-editor` so that it's fully visible on mobile
- [Frontend] Remove `overflow: hidden;` CSS rule on `table` element for the table header and footer to remain sticky on mobile